### PR TITLE
Zero-length equality

### DIFF
--- a/src/crypto/equality.clj
+++ b/src/crypto/equality.clj
@@ -6,7 +6,9 @@
   protects against timing attacks. Note that this does not prevent an attacker
   from discovering the *length* of the data being compared."
   [a b]
-  (let [a (map int a), b (map int b)]
-    (if (and a b (= (count a) (count b)))
+  (let [a (seq (map int a)), b (seq (map int b))]
+    (cond
+      (= nil a b) true
+      (and a b (= (count a) (count b)))
       (zero? (reduce bit-or (map bit-xor a b)))
-      false)))
+      :else false)))

--- a/test/crypto/equality_test.clj
+++ b/test/crypto/equality_test.clj
@@ -16,7 +16,8 @@
     (is (eq? "foo" "foo"))
     (is (eq? [1 2 3] [1 2 3]))
     (let [xs (take 1000 (repeatedly #(rand-int 1000000)))]
-      (is (eq? (vec xs) (vec xs)))))
+      (is (eq? (vec xs) (vec xs))))
+    (is (eq? "" "")))
   (testing "inequality"
     (is (not (eq? "foo" "bar")))
     (is (not (eq? "foo" "foob")))


### PR DESCRIPTION
I was playing with function specs, and happened to notice that when `crypto.equality/eq?` is given two zero-length strings or byte sequences, ie. `(eq? "" "")`, it throws:

```
1. Unhandled clojure.lang.ArityException
   Wrong number of args (0) passed to: core/bit-or
```

I understand that in the context this is normally used it should never really need to compare zero-length strings, but I thought I'd pass this along anyways. It just `seq`s the results of mapping `int` over the inputs, then short-circuits to true if both are nil.

If you ever want to add specs to the project later on, here's the spec that brought it to my attention:

```clojure
(s/fdef crypto.equality/eq?
        :args (s/cat :a string? :b string?)
        :ret boolean?
        :fn (fn [{:keys [args ret]}]
              (let [{:keys [a b]} args]
                (= (= a b)
                   ret))))
```


